### PR TITLE
getOptions > refactor code for reuse through multiple ESLibs

### DIFF
--- a/src/_index.js
+++ b/src/_index.js
@@ -1,7 +1,8 @@
 import {getSelectData, val} from "./data";
-import {eventData, fireOnChangeEvent, getID, getOptions, init} from "./methods";
+import {eventData, fireOnChangeEvent, init} from "./methods";
 import {getOptionHTML, updateDropdownHTML} from "./layout";
 import {findObjectInArray, getSelectTag, uniqueId} from "./utils";
+import {getOptions} from "@/helpers";
 
 const pluginName = "easySelect";
 const classes = {
@@ -71,8 +72,9 @@ class EasySelect{
         // avoid duplicate init
         if(this.selectTag.classList.contains(this.classes.enabled)) return;
 
+        // get options and assign ID
         this.config = getOptions(this, {...defaults, ...options});
-        this.id = getID(this);
+
         this.wrapper = this.selectTag.parentElement;
         this.dropdown = this.wrapper.querySelector(`.${this.classes.dropdown}`);
         this.current = this.wrapper.querySelector(`.${this.classes.current}`);

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -23,7 +23,7 @@ export function getOptions(context, defaultOptions){
 
     // data attribute is not json format or string
     if(attributeIsNotJSON){
-        options = defaultOptions;
+        options = {...defaultOptions};
 
         // data attribute exist => string
         if(dataAttribute) options.id = dataAttribute;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -7,7 +7,11 @@ import {isJSON} from "@/utils";
  * @returns {object}
  */
 export function getOptions(context, defaultOptions){
-    const numeric = []; // convert these props to float
+    if(!defaultOptions){
+        defaultOptions = context.options || context.config || {};
+    }
+
+    const numeric = ['autoShow']; // convert these props to float
     const wrapper = context.selectTag;
 
     // options from attribute
@@ -15,24 +19,26 @@ export function getOptions(context, defaultOptions){
     let options = {};
 
     // data attribute doesn't exist or not JSON format -> string
-    if(!dataAttribute || !isJSON(dataAttribute)){
-        // reassign id
-        const id = dataAttribute || wrapper.id || defaultOptions.id;
-        context.id = id;
-        defaultOptions.id = id;
+    const attributeIsNotJSON = !dataAttribute || !isJSON(dataAttribute);
 
-        return defaultOptions;
-    }
+    // data attribute is not json format or string
+    if(attributeIsNotJSON){
+        options = defaultOptions;
 
-    options = JSON.parse(dataAttribute);
+        // data attribute exist => string
+        if(dataAttribute) options.id = dataAttribute;
+        else options.id = '';
+    }else{
+        options = JSON.parse(dataAttribute);
 
-    for(const [key, value] of Object.entries(options)){
-        // convert boolean string to real boolean
-        if(value === "false") options[key] = false;
-        else if(value === "true") options[key] = true;
-        // convert string to float
-        else if(numeric.includes(key) && typeof value === 'string' && value.length > 0) options[key] = parseFloat(value);
-        else options[key] = value;
+        for(const [key, value] of Object.entries(options)){
+            // convert boolean string to real boolean
+            if(value === "false") options[key] = false;
+            else if(value === "true") options[key] = true;
+            // convert string to float
+            else if(numeric.includes(key) && typeof value === 'string' && value.length > 0) options[key] = parseFloat(value);
+            else options[key] = value;
+        }
     }
 
     // reassign id

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -42,8 +42,5 @@ export function getOptions(context, defaultOptions){
 
     options = {...defaultOptions, ...options};
 
-    // remove json
-    wrapper.removeAttribute(context.atts.init);
-
     return options;
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -2,6 +2,7 @@ import {isJSON} from "@/utils";
 
 /**
  * Get JSON options
+ * ID priority: data-attribute > selector#id > unique id
  * @version 0.0.1
  * @returns {object}
  */

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,0 +1,48 @@
+import {isJSON} from "@/utils";
+
+/**
+ * Get JSON options
+ * @version 0.0.1
+ * @returns {object}
+ */
+export function getOptions(context, defaultOptions){
+    const numeric = []; // convert these props to float
+    const wrapper = context.selectTag;
+
+    // options from attribute
+    let dataAttribute = wrapper.getAttribute(context.atts.init);
+    let options = {};
+
+    // data attribute doesn't exist or not JSON format -> string
+    if(!dataAttribute || !isJSON(dataAttribute)){
+        // reassign id
+        const id = dataAttribute || wrapper.id || defaultOptions.id;
+        context.id = id;
+        defaultOptions.id = id;
+
+        return defaultOptions;
+    }
+
+    options = JSON.parse(dataAttribute);
+
+    for(const [key, value] of Object.entries(options)){
+        // convert boolean string to real boolean
+        if(value === "false") options[key] = false;
+        else if(value === "true") options[key] = true;
+        // convert string to float
+        else if(numeric.includes(key) && typeof value === 'string' && value.length > 0) options[key] = parseFloat(value);
+        else options[key] = value;
+    }
+
+    // reassign id
+    const id = options.id || wrapper.id || defaultOptions.id;
+    context.id = id;
+    options.id = id;
+
+    options = {...defaultOptions, ...options};
+
+    // remove json
+    wrapper.removeAttribute(context.atts.init);
+
+    return options;
+}

--- a/src/methods.js
+++ b/src/methods.js
@@ -1,4 +1,4 @@
-import {createEl, insertAfter, isEmptyString, isJSON, wrapAll} from "./utils";
+import {createEl, insertAfter, wrapAll} from "./utils";
 import {getCurrentHTML, updateDropdownHTML} from "./layout";
 import {val} from "./data";
 
@@ -100,43 +100,6 @@ export function create(context){
     context.current.addEventListener('click', () => context.toggle());
 }
 
-
-/**
- * Get ID from attribute
- * @param context
- * @returns {*|string}
- */
-export function getID(context){
-    // id from data attribute
-    let id = context.selectTag.getAttribute(context.atts.init);
-
-    // string from init attribute always be treated as ID
-    if(isJSON(id)) return context.config.id;
-
-    // respect select#id
-    id = id !== null && !isEmptyString(id) ? id : context.selectTag.id;
-
-    // default unique id
-    id = id !== null && !isEmptyString(id) ? id : context.config.id;
-
-    return id;
-}
-
-export function getOptions(context, options){
-    // options from attribute
-    let string = context.selectTag.getAttribute(context.atts.init);
-
-    // option priority: attribute > js object > default
-    if(isJSON(string)) options = {...options, ...JSON.parse(string)};
-
-    // convert boolean string to real boolean
-    for(const [key, value] of Object.entries(options)){
-        if(value === "false") options[key] = false;
-        if(value === "true") options[key] = true;
-    }
-
-    return options;
-}
 
 /**
  * Fire on change event manually


### PR DESCRIPTION
Write the same `getOptions` function for making our code reusable and using through multiple ES Libraries (or any library that needs to get options from data-attribute) :
- [Easy Tab Accordion](https://github.com/viivue/easy-tab-accordion)
- [Easy Select](https://github.com/viivue/easy-select)
- [Easy Popup](https://github.com/viivue/easy-popup)

With the new `getOptions` function, we can get options and override them for each library option through data-attribute